### PR TITLE
fix(next): config

### DIFF
--- a/web/my-app/next.config.ts
+++ b/web/my-app/next.config.ts
@@ -2,7 +2,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: ["127.0.0.1"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
This avoids the following error when running the app in `dev` mode:
```shell
[15:10:14.941] ERROR (my-app/96753) <STDERR>:  ⚠ Blocked cross-origin request from 127.0.0.1 to /_next/* resource. To allow this, configure "allowedDevOrigins" in next.config
Read more: https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins
```